### PR TITLE
feat: :sparkles: Add the color guide to the excel template headers

### DIFF
--- a/dist/models/TemplateExcel.js
+++ b/dist/models/TemplateExcel.js
@@ -8,7 +8,15 @@ class TemplateExcel {
 		this._config = config;
 		this._validationRules = config.validationRules;
 		this._columns = config.columnNames;
+		this._headerColors = {
+			freeForm: 'FFE2EFDA',
+			semiFreeForm: 'FFFFF2CC',
+			restrictedForm: 'FFFCE4D6',
+		};
 		this._workbook = this._createTemplateExcel();
+	}
+	get headerColors() {
+		return this._headerColors;
 	}
 	_createTemplateExcel() {
 		const workbook = new exceljs_1.Workbook();
@@ -24,15 +32,24 @@ class TemplateExcel {
 		const coverSheet = workbook.addWorksheet('cover');
 		coverSheet.getCell('A1').value = `Template downloaded on: ${new Date()}`;
 		coverSheet.getCell('A2').value = `Configuration version: ${this._config.version}`;
+		coverSheet.getCell('A4').value = 'Color labels';
+		coverSheet.getCell('A5').fill = this.getCellStyleFill(this._headerColors.freeForm);
+		coverSheet.getCell('B5').value = 'Free field';
+		coverSheet.getCell('A6').fill = this.getCellStyleFill(this._headerColors.semiFreeForm);
+		coverSheet.getCell('B6').value = 'Free field, that needs to match the regular expression shown on note';
+		coverSheet.getCell('A7').fill = this.getCellStyleFill(this._headerColors.restrictedForm);
+		coverSheet.getCell('B7').value = 'Field restricted by the values list pre-defined on configuration';
 	}
 	_addExcelValidationWorksheet(workbook) {
-		const validationTemplate = workbook.addWorksheet('validation');
-		this._setExcelWorksheetHeader(validationTemplate);
-		this._setValidationExcelWorksheetValues(validationTemplate);
+		const validationSheet = workbook.addWorksheet('validation');
+		this._setExcelWorksheetHeader(validationSheet);
+		this._setHeaderFormat(validationSheet);
+		this._setValidationExcelWorksheetValues(validationSheet);
 	}
 	_addExcelTemplateWorksheet(workbook) {
 		const templateSheet = workbook.addWorksheet('template');
 		this._setExcelWorksheetHeader(templateSheet);
+		this._setHeaderFormat(templateSheet);
 		this._setTemplateExcelWorksheetDataValidation(templateSheet);
 	}
 	_setExcelWorksheetHeader(worksheet) {
@@ -47,23 +64,78 @@ class TemplateExcel {
 	}
 	_setValidationExcelWorksheetValues(validationWorksheet) {
 		this._columns.forEach((column) => {
-			validationWorksheet.getColumn(column).values = [column, ...this._validationRules[column]];
+			validationWorksheet.getColumn(column).values = [
+				column,
+				...this._validationRules[column].filter((item) => !StringUtils_1.StringUtils.isStringForRegex(item)),
+			];
 		});
+	}
+	_setHeaderFormat(worksheet) {
+		const columns = ['url', ...this._columns];
+		columns.forEach((column) => {
+			const cell = worksheet.getRow(1).getCell(column);
+			const config = this.getHeaderConfig(column);
+			cell.style = {
+				fill: this.getCellStyleFill(config.backgroundColor),
+				font: {
+					bold: true,
+				},
+			};
+			if (config.note)
+				cell.note = {
+					texts: [
+						{
+							text: config.note,
+						},
+					],
+				};
+		});
+	}
+	getHeaderConfig(column) {
+		if (column === 'url')
+			return {
+				note: null,
+				backgroundColor: this._headerColors.freeForm,
+			};
+		const validationRules = this._validationRules[column];
+		if (validationRules.filter((rule) => StringUtils_1.StringUtils.isStringForRegexAll(rule)).length > 0)
+			return {
+				note: null,
+				backgroundColor: this._headerColors.freeForm,
+			};
+		else if (validationRules.filter((rule) => StringUtils_1.StringUtils.isStringForRegex(rule)).length > 0)
+			return {
+				note: `Regexp: ${validationRules
+					.filter((rule) => StringUtils_1.StringUtils.isStringForRegex(rule))
+					.join(' ou ')}`,
+				backgroundColor: this._headerColors.semiFreeForm,
+			};
+		else
+			return {
+				note: null,
+				backgroundColor: this._headerColors.restrictedForm,
+			};
 	}
 	_setTemplateExcelWorksheetDataValidation(templateWorksheet) {
 		this._columns.forEach((column) => {
-			if (!StringUtils_1.StringUtils.isStringForRegex(this._validationRules[column][0])) {
-				const validationCount = this._validationRules[column].length;
-				const columnLetter = templateWorksheet.getColumn(column).letter;
-				for (let i = 2; i < 1003; i++) {
-					templateWorksheet.getCell(columnLetter + i).dataValidation = {
-						type: 'list',
-						allowBlank: false,
-						formulae: [`=validation!$${columnLetter}$2:$${columnLetter}$${validationCount + 1}`],
-					};
-				}
+			const columnLetter = templateWorksheet.getColumn(column).letter;
+			for (let i = 2; i < 1003; i++) {
+				templateWorksheet.getCell(columnLetter + i).dataValidation = {
+					type: 'list',
+					allowBlank: false,
+					formulae: [`=validation!$${columnLetter}$2:$${columnLetter}$1000`],
+				};
 			}
 		});
+	}
+	getCellStyleFill(argb) {
+		return {
+			type: 'pattern',
+			pattern: 'solid',
+			fgColor: {
+				argb: argb,
+			},
+		};
 	}
 }
 exports.TemplateExcel = TemplateExcel;

--- a/dist/utils/StringUtils.js
+++ b/dist/utils/StringUtils.js
@@ -18,6 +18,9 @@ class StringUtils {
 	static isStringForRegex(string) {
 		return string[0] === '/' && string[string.length - 1] === '/';
 	}
+	static isStringForRegexAll(string) {
+		return string === '/.*/';
+	}
 	static validateString(stringToValidate, rules, separator = ' ') {
 		const validate = [false];
 		rules.forEach((rule) => {

--- a/src/ts/models/TemplateExcel.ts
+++ b/src/ts/models/TemplateExcel.ts
@@ -1,4 +1,4 @@
-import { Buffer, Workbook, Worksheet } from 'exceljs';
+import { Border, Buffer, Fill, Workbook, Worksheet } from 'exceljs';
 import { StringUtils } from '../utils/StringUtils';
 import { Config } from './Config';
 
@@ -7,12 +7,22 @@ export class TemplateExcel {
 	private _validationRules: { [key: string]: string[] };
 	private _columns: string[];
 	private _workbook: Workbook;
+	private _headerColors: { freeForm: string; semiFreeForm: string; restrictedForm: string };
 
 	constructor(config: Config) {
 		this._config = config;
 		this._validationRules = config.validationRules;
 		this._columns = config.columnNames;
+		this._headerColors = {
+			freeForm: 'FFE2EFDA',
+			semiFreeForm: 'FFFFF2CC',
+			restrictedForm: 'FFFCE4D6',
+		};
 		this._workbook = this._createTemplateExcel();
+	}
+
+	get headerColors(): { freeForm: string; semiFreeForm: string; restrictedForm: string } {
+		return this._headerColors;
 	}
 
 	/**
@@ -36,13 +46,20 @@ export class TemplateExcel {
 	}
 
 	/**
-	 * Gerar a aba 'cover' no Excel Template, contendo informações do template, como data de download e versão da configuração.
+	 * Gerar a aba 'cover' no Excel Template, contendo informações do template, como data de download, versão da configuração e legenda das cores do header.
 	 * @param workbook Objeto Workbook no qual a aba será gerada.
 	 */
 	private _addExcelCoverWorksheet(workbook: Workbook): void {
 		const coverSheet = workbook.addWorksheet('cover');
 		coverSheet.getCell('A1').value = `Template downloaded on: ${new Date()}`;
 		coverSheet.getCell('A2').value = `Configuration version: ${this._config.version}`;
+		coverSheet.getCell('A4').value = 'Color labels';
+		coverSheet.getCell('A5').fill = this.getCellStyleFill(this._headerColors.freeForm);
+		coverSheet.getCell('B5').value = 'Free field';
+		coverSheet.getCell('A6').fill = this.getCellStyleFill(this._headerColors.semiFreeForm);
+		coverSheet.getCell('B6').value = 'Free field, that needs to match the regular expression shown on note';
+		coverSheet.getCell('A7').fill = this.getCellStyleFill(this._headerColors.restrictedForm);
+		coverSheet.getCell('B7').value = 'Field restricted by the values list pre-defined on configuration';
 	}
 
 	/**
@@ -50,9 +67,10 @@ export class TemplateExcel {
 	 * @param workbook Objeto Workbook no qual a aba será gerada.
 	 */
 	private _addExcelValidationWorksheet(workbook: Workbook): void {
-		const validationTemplate = workbook.addWorksheet('validation');
-		this._setExcelWorksheetHeader(validationTemplate);
-		this._setValidationExcelWorksheetValues(validationTemplate);
+		const validationSheet = workbook.addWorksheet('validation');
+		this._setExcelWorksheetHeader(validationSheet);
+		this._setHeaderFormat(validationSheet);
+		this._setValidationExcelWorksheetValues(validationSheet);
 	}
 
 	/**
@@ -62,6 +80,7 @@ export class TemplateExcel {
 	private _addExcelTemplateWorksheet(workbook: Workbook): void {
 		const templateSheet = workbook.addWorksheet('template');
 		this._setExcelWorksheetHeader(templateSheet);
+		this._setHeaderFormat(templateSheet);
 		this._setTemplateExcelWorksheetDataValidation(templateSheet);
 	}
 
@@ -82,12 +101,73 @@ export class TemplateExcel {
 
 	/**
 	 * Inserir o nome do campo e os valores de cada campo que serão usados para validação de dados, de acordo com a configuração de validação do AdInfo.
+	 * Caso a regra de validação dos dados seja uma expressão regular, ela não entrará como opção de valor.
 	 * @param validationWorksheet Objeto Worksheet (aba do Excel) referente à aba de validação.
 	 */
 	private _setValidationExcelWorksheetValues(validationWorksheet: Worksheet): void {
 		this._columns.forEach((column) => {
-			validationWorksheet.getColumn(column).values = [column, ...this._validationRules[column]];
+			validationWorksheet.getColumn(column).values = [
+				column,
+				...this._validationRules[column].filter((item) => !StringUtils.isStringForRegex(item)),
+			];
 		});
+	}
+
+	/**
+	 * Aplicação da formatação do header, com a formatação da cor de fundo da célula e a adição da nota, quando necessária.
+	 * @param worksheet Objeto Worksheet
+	 */
+	private _setHeaderFormat(worksheet: Worksheet): void {
+		const columns = ['url', ...this._columns];
+		columns.forEach((column) => {
+			const cell = worksheet.getRow(1).getCell(column);
+			const config = this.getHeaderConfig(column);
+			cell.style = {
+				fill: this.getCellStyleFill(config.backgroundColor),
+				font: {
+					bold: true,
+				},
+			};
+			if (config.note)
+				cell.note = {
+					texts: [
+						{
+							text: config.note,
+						},
+					],
+				};
+		});
+	}
+
+	/**
+	 * Retorna a configuração da célula do header de acordo com o nome da coluna.
+	 * @param column Nome da coluna
+	 * @returns JSON que contém:
+	 * 	- backgroundColor: o ARGB da cor de fundo da célula
+	 *  - note: se o campo for de preenchimento livre ou de preenchimento restrito, retornará note como null. Caso contrário, ou seja, o campo tenha validação de valores com uma regexp, que não seja tudo, a nota vai conter a regexp correspondente.
+	 */
+	getHeaderConfig(column: string): { note: string; backgroundColor: string } {
+		if (column === 'url')
+			return {
+				note: null,
+				backgroundColor: this._headerColors.freeForm,
+			};
+		const validationRules = this._validationRules[column];
+		if (validationRules.filter((rule) => StringUtils.isStringForRegexAll(rule)).length > 0)
+			return {
+				note: null,
+				backgroundColor: this._headerColors.freeForm,
+			};
+		else if (validationRules.filter((rule) => StringUtils.isStringForRegex(rule)).length > 0)
+			return {
+				note: `Regexp: ${validationRules.filter((rule) => StringUtils.isStringForRegex(rule)).join(' ou ')}`,
+				backgroundColor: this._headerColors.semiFreeForm,
+			};
+		else
+			return {
+				note: null,
+				backgroundColor: this._headerColors.restrictedForm,
+			};
 	}
 
 	/**
@@ -96,17 +176,29 @@ export class TemplateExcel {
 	 */
 	private _setTemplateExcelWorksheetDataValidation(templateWorksheet: Worksheet): void {
 		this._columns.forEach((column) => {
-			if (!StringUtils.isStringForRegex(this._validationRules[column][0])) {
-				const validationCount = this._validationRules[column].length;
-				const columnLetter = templateWorksheet.getColumn(column).letter;
-				for (let i = 2; i < 1003; i++) {
-					templateWorksheet.getCell(columnLetter + i).dataValidation = {
-						type: 'list',
-						allowBlank: false,
-						formulae: [`=validation!$${columnLetter}$2:$${columnLetter}$${validationCount + 1}`],
-					};
-				}
+			const columnLetter = templateWorksheet.getColumn(column).letter;
+			for (let i = 2; i < 1003; i++) {
+				templateWorksheet.getCell(columnLetter + i).dataValidation = {
+					type: 'list',
+					allowBlank: false,
+					formulae: [`=validation!$${columnLetter}$2:$${columnLetter}$1000`],
+				};
 			}
 		});
+	}
+
+	/**
+	 * Retorna a configuração da cor de fundo da célula do Excel.
+	 * @param argb String que corresponde ao código argb da cor de funco da célula do Excel.
+	 * @returns Fill: Objeto utilizado na configuração da cor de fundo da célula do Excel.
+	 */
+	getCellStyleFill(argb: string): Fill {
+		return {
+			type: 'pattern',
+			pattern: 'solid',
+			fgColor: {
+				argb: argb,
+			},
+		};
 	}
 }

--- a/src/ts/utils/StringUtils.ts
+++ b/src/ts/utils/StringUtils.ts
@@ -42,6 +42,15 @@ export class StringUtils {
 	}
 
 	/**
+	 *
+	 * @param string Verifica se a string corresponde exatamente à expressão regular /.*\/
+	 * @returns TRUE: String é a expressão regular /.*\/, FALSE: String não é a expressão regular /.*\/
+	 */
+	static isStringForRegexAll(string: string): boolean {
+		return string === '/.*/';
+	}
+
+	/**
 	 * Valida se a String está dentro de um padrão
 	 * @param stringToValidate String a ser validada
 	 * @param rules Array contendo as string que de comparação ou as regex

--- a/test/models/TemplateExcel.spec.ts
+++ b/test/models/TemplateExcel.spec.ts
@@ -1,0 +1,66 @@
+import { expect } from 'chai';
+import { TemplateExcel } from '../../src/ts/models/TemplateExcel';
+import { Config } from '../../src/ts/models/Config';
+
+describe('TemplateExcel', () => {
+	const config = new Config({
+		separator: ':',
+		spaceSeparator: '_',
+		columns: {
+			'Tipo de Compra': ['cpa', 'cpc', '/cp./'],
+			'Veiculo': ['/(?i)google/', '/(?i)facebook/'],
+			'Produto': ['/.*/'],
+			'Tipo de Midia': ['display', 'video', 'stories'],
+		},
+		adobe: {
+			cid: ['Tipo de Compra', 'Produto', 'Tipo de Midia'],
+		},
+	});
+	const templateExcel = new TemplateExcel(config);
+
+	describe('Header configuration', () => {
+		it('Header do campo de livre preenchimento', () => {
+			expect(
+				JSON.stringify(templateExcel.getHeaderConfig('Produto'))
+			).to.equal(JSON.stringify({
+				note: null,
+				backgroundColor: templateExcel.headerColors.freeForm
+			}));
+		});
+		it('Header do campo de preenchimento segundo regra de expressã o regular', () => {
+			expect(
+				JSON.stringify(templateExcel.getHeaderConfig('Tipo de Compra'))
+			).to.equal(JSON.stringify({
+				note: 'Regexp: /cp./',
+				backgroundColor: templateExcel.headerColors.semiFreeForm}));
+			expect(
+				JSON.stringify(templateExcel.getHeaderConfig('Veiculo'))
+			).to.equal(JSON.stringify({
+				note: 'Regexp: /(?i)google/ ou /(?i)facebook/',
+				backgroundColor: templateExcel.headerColors.semiFreeForm
+			}));
+		})
+		it('Header do campo restrito à lista de valores pré-definidos na configuração', () => {
+			expect(
+				JSON.stringify(templateExcel.getHeaderConfig('Tipo de Midia'))
+			).to.equal(JSON.stringify({
+				note: null,
+				backgroundColor: templateExcel.headerColors.restrictedForm
+			}));
+		})
+	});
+
+	describe('Configuração da cor de fundo', () => {
+		it('Cor de fundo', () => {
+			expect(
+				JSON.stringify(templateExcel.getCellStyleFill('FFFFFFFF'))
+			).to.equal(JSON.stringify({
+				type: 'pattern',
+				pattern: 'solid',
+				fgColor: {
+					argb: 'FFFFFFFF'
+				}
+			}))
+		})
+	})
+});

--- a/test/utils/StringUtils.spec.ts
+++ b/test/utils/StringUtils.spec.ts
@@ -56,4 +56,23 @@ describe('String Utils', () => {
 			expect(StringUtils.isEmpty('teste')).to.equal(false);
 		});
 	});
+	describe('Regex', () => {
+		it('Valida se a função verifica se a string corresponde à uma expressão regular', () => {
+			expect(
+				StringUtils.isStringForRegex('/cp./')
+			).to.equal(true);
+			expect(
+				StringUtils.isStringForRegex('/cp.')
+			).to.equal(false);
+		});
+		it('Valida se a função verifica se a string correponde exatamente à expressão regular /.*/', () => {
+			expect(
+				StringUtils.isStringForRegexAll('/.*/')
+			).to.equal(true);
+			expect(
+				StringUtils.isStringForRegexAll('/cp.')
+			).to.equal(false);
+		})
+	})
+
 });


### PR DESCRIPTION
Add a color guide to excel template headers to indicate if the column is freeform or not

**What changes did you make?**
- Added StringUtils functions
- Updated the TemplateExcel class, with the new feature
- Added unit test for StringUtils regex functions
- Added unit test for some TemplateExcel methods
