### PR TITLE
feat: :sparkles: Add parameterization output save feature

### DIFF
--- a/dist/routes/build.js
+++ b/dist/routes/build.js
@@ -67,11 +67,13 @@ const build = (app) => {
 					(err, csv) => {
 						csv += '\n\nConfiguracao versao' + separator + configVersion;
 						csv += '\nConfiguracao inserida em' + separator + configTimestamp;
-						res.setHeader('Content-disposition', 'attachment; filename=data.csv');
-						res.set('Content-Type', 'text/csv; charset=utf-8');
-						apiResponse.responseText = csv;
-						apiResponse.statusCode = 200;
-						res.status(apiResponse.statusCode).send(apiResponse.responseText);
+						saveParameterizedFile(csv, filePath).then(() => {
+							res.setHeader('Content-disposition', 'attachment; filename=data.csv');
+							res.set('Content-Type', 'text/csv; charset=utf-8');
+							apiResponse.responseText = csv;
+							apiResponse.statusCode = 200;
+							res.status(apiResponse.statusCode).send(apiResponse.responseText);
+						});
 					},
 					{
 						delimiter: {
@@ -93,5 +95,10 @@ const build = (app) => {
 				}
 			});
 	});
+};
+const saveParameterizedFile = (csv, inputFilePath) => {
+	const fileDao = new FileDAO_1.FileDAO();
+	fileDao.file = Buffer.from(csv, 'utf8');
+	return fileDao.save(inputFilePath.replace('.csv', '_parametrizado.csv'));
 };
 exports.default = build;

--- a/src/ts/routes/build.ts
+++ b/src/ts/routes/build.ts
@@ -69,11 +69,13 @@ const build = (app: { [key: string]: any }): void => {
 					(err, csv) => {
 						csv += '\n\nConfiguracao versao' + separator + configVersion;
 						csv += '\nConfiguracao inserida em' + separator + configTimestamp;
-						res.setHeader('Content-disposition', 'attachment; filename=data.csv');
-						res.set('Content-Type', 'text/csv; charset=utf-8');
-						apiResponse.responseText = csv;
-						apiResponse.statusCode = 200;
-						res.status(apiResponse.statusCode).send(apiResponse.responseText);
+						saveParameterizedFile(csv, filePath).then(() => {
+							res.setHeader('Content-disposition', 'attachment; filename=data.csv');
+							res.set('Content-Type', 'text/csv; charset=utf-8');
+							apiResponse.responseText = csv;
+							apiResponse.statusCode = 200;
+							res.status(apiResponse.statusCode).send(apiResponse.responseText);
+						});
 					},
 					{
 						delimiter: {
@@ -95,6 +97,17 @@ const build = (app: { [key: string]: any }): void => {
 				}
 			});
 	});
+};
+
+/**
+ * Salva o output da parametrização no Storage. O caminho da pasta é a mesma onde é salvo o input, porém apenas com o sufixo "_parametrizado"
+ * @param csv Conteudo do csv
+ * @param inputFilePath Caminho do arquivo csv de input
+ */
+const saveParameterizedFile = (csv: string, inputFilePath: string): Promise<void> => {
+	const fileDao = new FileDAO();
+	fileDao.file = Buffer.from(csv, 'utf8');
+	return fileDao.save(inputFilePath.replace('.csv', '_parametrizado.csv'));
 };
 
 export default build;


### PR DESCRIPTION
Add parameterization output save on Storage feature

**What changes did you make?**
- Add a function to save the output of the parameterization on Google Cloud Storage. The file's name follows the same standard used on the input file. The only difference is that it comes with the "_parametrizado" suffix.
